### PR TITLE
Add relays field to NIP-05 identifier

### DIFF
--- a/.well-known/nostr.json
+++ b/.well-known/nostr.json
@@ -1,5 +1,19 @@
 {
   "names": {
-    "ben": "971615b70ad9ec896f8d5ba0f2d01652f1dfe5f9ced81ac9469ca7facefad68b" 
+    "ben": "971615b70ad9ec896f8d5ba0f2d01652f1dfe5f9ced81ac9469ca7facefad68b"
+  },
+  "relays": {
+    "971615b70ad9ec896f8d5ba0f2d01652f1dfe5f9ced81ac9469ca7facefad68b": [
+      "wss://relay.damus.io",
+      "wss://nostr.wine",
+      "wss://nostr.oxtr.dev",
+      "wss://nostr.land",
+      "wss://relay.primal.net",
+      "wss://nostr.bitcoiner.social",
+      "wss://nos.lol",
+      "wss://relay.snort.social",
+      "wss://eden.nostr.land",
+      "wss://relay.nostr.band"
+    ]
   }
 }


### PR DESCRIPTION
## Summary

- Adds the `relays` field to `.well-known/nostr.json` to enable LNbits Nostr notifications
- Includes 10 active relay URLs from the LNbits Nostrclient extension configuration

## Background

While the `relays` field is optional per the NIP-05 specification, LNbits requires it to send direct message notifications. Without this field, notifications silently fail with no error message.

## Changes

Added the `relays` object mapping the public key to an array of 10 Nostr relay WebSocket URLs:
- wss://relay.damus.io
- wss://nostr.wine
- wss://nostr.oxtr.dev
- wss://nostr.land
- wss://relay.primal.net
- wss://nostr.bitcoiner.social
- wss://nos.lol
- wss://relay.snort.social
- wss://eden.nostr.land
- wss://relay.nostr.band

## Test Plan

- [ ] Verify file is accessible at `https://benweeks.github.io/.well-known/nostr.json`
- [ ] Validate JSON structure is correct
- [ ] Test LNbits Nostr notifications work after deployment

## Related

Related to lnbits/lnbits#3435 (upstream issue about silent failures)

🤖 Generated with [Claude Code](https://claude.com/claude-code)